### PR TITLE
Make LogSeverity conform to Swift's Comparable protocol

### DIFF
--- a/CleanroomLogger.xcodeproj/project.pbxproj
+++ b/CleanroomLogger.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3B4596E11AE196E50049A743 /* LogRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4596D61AE196E50049A743 /* LogRecorder.swift */; };
 		3B4596E21AE196E50049A743 /* LogSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4596D71AE196E50049A743 /* LogSeverity.swift */; };
 		3B4596E31AE196FB0049A743 /* CleanroomASL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B4596C91AE196730049A743 /* CleanroomASL.framework */; };
+		6911AE911B0C264D0035F749 /* LogSeverityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6911AE901B0C264D0035F749 /* LogSeverityTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 		3B4596D51AE196E50049A743 /* LogReceptacle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogReceptacle.swift; path = Code/LogReceptacle.swift; sourceTree = SOURCE_ROOT; };
 		3B4596D61AE196E50049A743 /* LogRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogRecorder.swift; path = Code/LogRecorder.swift; sourceTree = SOURCE_ROOT; };
 		3B4596D71AE196E50049A743 /* LogSeverity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogSeverity.swift; path = Code/LogSeverity.swift; sourceTree = SOURCE_ROOT; };
+		6911AE901B0C264D0035F749 /* LogSeverityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogSeverityTests.swift; path = Code/Tests/LogSeverityTests.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +127,7 @@
 		3B4596B51AE195900049A743 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6911AE901B0C264D0035F749 /* LogSeverityTests.swift */,
 			);
 			name = Tests;
 			path = CleanroomLoggerTests;
@@ -307,6 +310,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6911AE911B0C264D0035F749 /* LogSeverityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Code/Log.swift
+++ b/Code/Log.swift
@@ -325,7 +325,7 @@ public struct Log
     private static func createLogChannelWithSeverity(severity: LogSeverity, receptacle: LogReceptacle, minimumSeverity: LogSeverity)
         -> LogChannel?
     {
-        if severity.compare(.AsOrMoreSevereThan, against: minimumSeverity) {
+        if severity >= minimumSeverity {
             return LogChannel(severity: severity, receptacle: receptacle)
         }
         return nil

--- a/Code/LogFilter.swift
+++ b/Code/LogFilter.swift
@@ -59,6 +59,6 @@ public struct LogSeverityFilter: LogFilter
     public func shouldRecordLogEntry(entry: LogEntry)
         -> Bool
     {
-        return entry.severity.compare(.AsOrMoreSevereThan, against: severity)
+        return entry.severity >= severity
     }
 }

--- a/Code/LogReceptacle.swift
+++ b/Code/LogReceptacle.swift
@@ -80,7 +80,7 @@ public final class LogReceptacle
         -> LogConfiguration?
     {
         for config in configuration {
-            if entry.severity.compare(.AsOrMoreSevereThan, against: config.minimumSeverity) {
+            if entry.severity >= config.minimumSeverity {
                 return config
             }
         }

--- a/Code/LogSeverity.swift
+++ b/Code/LogSeverity.swift
@@ -37,89 +37,7 @@ public enum LogSeverity: Int
     /** The highest severity, used to indicate that something has gone wrong;
     a fatal error may be imminent. */
     case Error      = 5
-
-    /**
-    The `LogSeverity.Comparator` is used to compare `LogSeverity` values.
-    */
-    public enum Comparator
-    {
-        /** Represents a comparator whose `compare()` function will return
-        `true` when the value of the `lVal` argument is less severe than that
-        of the `rVal` argument. */
-        case LessSevereThan
-
-        /** Represents a comparator whose `compare()` function will return
-        `true` when the value of the `lVal` argument is as or less severe than
-        that of the `rVal` argument. */
-        case AsOrLessSevereThan
-
-        /** Represents a comparator whose `compare()` function will return
-        `true` when the value of the `lVal` argument is equal to that of the
-        `rVal` argument. */
-        case EqualToSeverityOf
-
-        /** Represents a comparator whose `compare()` function will return
-        `true` when the value of the `lVal` argument is as or more severe than
-        that of the `rVal` argument. */
-        case AsOrMoreSevereThan
-
-        /** Represents a comparator whose `compare()` function will return
-        `true` when the value of the `lVal` argument is more severe than
-        that of the `rVal` argument. */
-        case MoreSevereThan
-
-        /**
-        Executes the function represented by the comparator using the
-        specified `lVal` and `rVal` arguments.
-        
-        :param:     lVal The lefthand value for the comparison
-        
-        :param:     rVal The righthand value for the comparison
-        
-        :returns:   The result of the comparison given the values `lVal` and
-                    `rVal`.
-        */
-        public func compare(lVal: LogSeverity, against rVal: LogSeverity)
-            -> Bool
-        {
-            switch self {
-            case LessSevereThan:
-                return lVal.rawValue < rVal.rawValue
-
-            case AsOrLessSevereThan:
-                return lVal.rawValue <= rVal.rawValue
-
-            case EqualToSeverityOf:
-                return lVal.rawValue == rVal.rawValue
-
-            case AsOrMoreSevereThan:
-                return lVal.rawValue >= rVal.rawValue
-                
-            case MoreSevereThan:
-                return lVal.rawValue > rVal.rawValue
-            }
-        }
-    }
-
-    /**
-    Compares the receiver against another `LogSeverity` value using the given
-    comparator.
-
-    :param:     comparator The `LogSeverity.Comparator` to use for the 
-                comparison.
     
-    :param:     severity The `LogSeverity` value being compared against the
-                receiver. This value represents the righthand value in the
-                comparison, while the receiver represents the lefthand value.
-    
-    :returns:   The result of the comparison.
-    */
-    public func compare(comparator: Comparator, against severity: LogSeverity)
-        -> Bool
-    {
-        return comparator.compare(self, against: severity)
-    }
-
     /**
     A convenience function to determine the minimum `LogSeverity` value to
     use by default, based on whether or not the application was compiled
@@ -140,6 +58,14 @@ public enum LogSeverity: Int
             return .Info
         }
     }
+}
+
+/// :nodoc:
+extension LogSeverity: Comparable {}
+
+/// :nodoc:
+public func <(lhs: LogSeverity, rhs: LogSeverity) -> Bool {
+    return lhs.rawValue < rhs.rawValue
 }
 
 /// :nodoc:

--- a/Code/Tests/LogSeverityTests.swift
+++ b/Code/Tests/LogSeverityTests.swift
@@ -1,0 +1,25 @@
+//
+//  LogSeverityTests.swift
+//  Cleanroom Project
+//
+//  Created by Claudio Romandini on 19/5/15.
+//  Copyright (c) 2015 Gilt Groupe. All rights reserved.
+//
+
+import XCTest
+import CleanroomLogger
+
+class LogSeverityTests: XCTestCase {
+
+    func testLogSeverity_Equality() {
+        XCTAssertTrue(LogSeverity.Debug == LogSeverity.Debug, "Debug should be equal to itself.")
+        XCTAssertTrue(LogSeverity.Info != LogSeverity.Warning, "Info should be not equal to Warning.")
+    }
+    
+    func testLogSeverity_ComparableImplementation() {
+        XCTAssertTrue(LogSeverity.Verbose < LogSeverity.Debug, "Verbose should be less than Debug.")
+        XCTAssertTrue(LogSeverity.Info >= LogSeverity.Debug, "Info should be greater than or equal to Debug.")
+        XCTAssertTrue(LogSeverity.Warning > LogSeverity.Info, "Warning should be greater than Info.")
+        XCTAssertTrue(LogSeverity.Warning <= LogSeverity.Error, "Warning should be less than or equal to Error.")
+    }
+}


### PR DESCRIPTION
I cleaned up a lot of code by leveraging Swift's Comparable protocol, I hope you like it!