### PR TITLE
Fix script to handle platforms with a space

### DIFF
--- a/BuildControl/bin/stripCarthageFrameworks.sh
+++ b/BuildControl/bin/stripCarthageFrameworks.sh
@@ -57,7 +57,7 @@ fi
 #
 PLAT_COUNT=0
 for PLAT_PATH in "$CARTHAGE_BUILD_DIR/"*; do
-	PLAT=`basename $PLAT_PATH`
+	PLAT=$(basename "$PLAT_PATH")
 
 	if [[ -z "$VALID_PLATFORMS" ]]; then
 		VALID_PLATFORMS=$PLAT	


### PR DESCRIPTION
My platform had a space in it and the syntax used here didn't handle that. I made a minor tweak so it works.