### PR TITLE
Updated complicated example so that it works better out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,11 +463,13 @@ if let osLog = OSLogRecorder(formatters: [ReadableLogFormatter()]) {
 	configs.append(BasicLogConfiguration(recorders: [osLog]))
 }
 
-// create a configuration for a 15-day rotating log directory
+// create a configuration for a 15-day rotating log directory in the app's Caches directory
+let cachesDir = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
+let logsPath = cachesDir + "/CleanroomLogger"
 let fileCfg = RotatingLogFileConfiguration(minimumSeverity: .info,
-												daysToKeep: 15,
-											 directoryPath: "/tmp/CleanroomLogger",
-												formatters: [ParsableLogFormatter()])
+					   daysToKeep: 15,
+					   directoryPath: logsPath,
+					   formatters: [ParsableLogFormatter()])
 
 // crash if the log directory doesn’t exist yet & can’t be created
 try! fileCfg.createLogDirectory()


### PR DESCRIPTION
Added a couple lines of code to get the actual path to the caches directory within the app sandbox and then append "/CleanroomLogger" so that this section of code is more plug 'n play. With these couple lines of code, it makes it easier for a new user to CleanroomLogger to copy and paste and get going. Obviously, the previous path does not work out of the box because it is not the full path to the app's sandbox. 
Plus, it may encourage users to put logs in the Caches directory in case an iPhone user is low on space and the logs are taking up a lot of room. If desired, we could easily switch the sample code to use ```.documentDirectory``` instead.
Also, fixed the formatting of the RotatingLogFIleConfiguration initializer because the last few parameters were off the screen.