### PR TITLE
Change prune whitelist calendar math so first of month minus one day …

### DIFF
--- a/Sources/RotatingLogFileRecorder.swift
+++ b/Sources/RotatingLogFileRecorder.swift
@@ -158,7 +158,7 @@ open class RotatingLogFileRecorder: LogRecorderBase
         for _ in 0..<daysToKeep {
             let filename = type(of: self).logFilename(forDate: date)
             filesToKeep.insert(filename)
-            date = cal.date(byAdding: .day, value: -1, to: date, wrappingComponents: true)!
+            date = cal.date(byAdding: .day, value: -1, to: date)!
         }
 
         do {


### PR DESCRIPTION
…is the last day of the previous month

At month start, the prune whitelist takes the current day and starts subtracting days to generate a whilelist of acceptable filenames. 

Currently, with `wrappingComponents: true` on the first of the month subtracting a day yields the last day of the same month. The result is that a maintained log directory is completely wiped at month start.

Example of a 14 day retention policy when system date is 10-1 with current implementation: 
```Printing description of filesToKeep:
▿ 14 elements
  - 0 : "2017-10-19.log"
  - 1 : "2017-10-25.log"
  - 2 : "2017-10-29.log"
  - 3 : "2017-10-21.log"
  - 4 : "2017-10-30.log"
  - 5 : "2017-10-28.log"
  - 6 : "2017-10-24.log"
  - 7 : "2017-10-01.log"
  - 8 : "2017-10-31.log"
  - 9 : "2017-10-27.log"
  - 10 : "2017-10-22.log"
  - 11 : "2017-10-26.log"
  - 12 : "2017-10-23.log"
  - 13 : "2017-10-20.log"
```

After this proposed change:
```
Printing description of filesToKeep:
▿ 14 elements
  - 0 : "2017-09-23.log"
  - 1 : "2017-09-25.log"
  - 2 : "2017-09-19.log"
  - 3 : "2017-09-24.log"
  - 4 : "2017-09-30.log"
  - 5 : "2017-09-18.log"
  - 6 : "2017-09-22.log"
  - 7 : "2017-09-28.log"
  - 8 : "2017-09-20.log"
  - 9 : "2017-10-01.log"
  - 10 : "2017-09-21.log"
  - 11 : "2017-09-27.log"
  - 12 : "2017-09-26.log"
  - 13 : "2017-09-29.log"
(lldb) 
```