### PR TITLE
Update config VALID_ARCHS for 64-bit Watch

### DIFF
--- a/BuildControl/config/Project.xcconfig
+++ b/BuildControl/config/Project.xcconfig
@@ -47,7 +47,7 @@ ENABLE_BITCODE[sdk=appletv*] = YES
 //
 WATCHOS_DEPLOYMENT_TARGET = 2.0
 
-VALID_ARCHS[sdk=watchos*] = armv7k
+VALID_ARCHS[sdk=watchos*] = arm64_32 armv7k
 VALID_ARCHS[sdk=watchsimulator*] = i386
 
 LD_RUNPATH_SEARCH_PATHS[sdk=watchos*] =  @executable_path/Frameworks @loader_path/Frameworks


### PR DESCRIPTION
Cupertino has introduced a 64-bit S4 chip in the Apple Watch Series 4. Therefore, frameworks must be build targeting a new `arm64_32` `ARCH`.

Since CleanroomLogger enumerates `VALID_ARCH`s in the project `.xcconfig`, this will need to be updated when a new processor architecture is introduced in a shipping product, as has happened recently. This PR updates the config accordingly.