### PR TITLE
Swift 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,19 @@
+// swift-tools-version:5.1
+
 import PackageDescription
 
 let package = Package(
-	name: "CleanroomLogger"
+    name: "CleanroomLogger",
+    products: [
+        .library(
+            name: "CleanroomLogger",
+            targets: ["CleanroomLogger"]),
+    ],
+    targets: [
+        .target(
+            name: "CleanroomLogger",
+            dependencies: [],
+            path: "Sources"),
+    ]
 )
+

--- a/Sources/BasicLogConfiguration.swift
+++ b/Sources/BasicLogConfiguration.swift
@@ -13,17 +13,17 @@
 open class BasicLogConfiguration: LogConfiguration
 {
     /** The minimum `LogSeverity` supported by the configuration. */
-    open let minimumSeverity: LogSeverity
+    public let minimumSeverity: LogSeverity
 
     /** The `LogFilter`s to use when deciding whether a given `LogEntry` should
      be passed along to the receiver's `recorders`. If any filter returns
      `false` from `shouldRecordLogEntry(_:)`, the `LogEntry` will be silently
      ignored when being processed for this `LogConfiguration`. */
-    open let filters: [LogFilter]
+    public let filters: [LogFilter]
 
     /** The `LogRecorder`s to use for recording any `LogEntry` that has passed
      the filtering process. */
-    open let recorders: [LogRecorder]
+    public let recorders: [LogRecorder]
 
     /** A flag indicating whether synchronous mode will be used when passing
      `LogEntry` instances to the receiver's `recorders`. Synchronous mode is
@@ -31,13 +31,13 @@ open class BasicLogConfiguration: LogConfiguration
      when debug breakpoints are hit. However, synchronous mode can have a
      negative influence on performance and is therefore not recommended for use 
      in production code. */
-    open let synchronousMode: Bool
+    public let synchronousMode: Bool
 
     /** For organizational purposes, a given `LogConfiguration` may in turn
      contain one or more additional `LogConfiguration`s. Each contained
      `LogConfiguration` is an entirely separate entity; children do not inherit
      any state from parent containers. */
-    open let configurations: [LogConfiguration]?
+    public let configurations: [LogConfiguration]?
 
     /**
      Initializes a new `BasicLogConfiguration` instance.

--- a/Sources/BufferedLogRecorder.swift
+++ b/Sources/BufferedLogRecorder.swift
@@ -29,11 +29,11 @@ open class BufferedLogRecorder<BufferItem>: LogRecorderBase
 {
     /** The maximum number if items that will be stored in the receiver's
      buffer */
-    open let bufferLimit: Int
+    public let bufferLimit: Int
 
     /** The function used to create a `BufferItem` given a `LogEntry` and a
      formatted message string. */
-    open let createBufferItem: (LogEntry, String) -> BufferItem
+    public let createBufferItem: (LogEntry, String) -> BufferItem
 
     /** The buffer, an array of `BufferItem`s created to represent the 
      `LogEntry` values recorded by the receiver. */

--- a/Sources/ConcatenatingLogFormatter.swift
+++ b/Sources/ConcatenatingLogFormatter.swift
@@ -13,7 +13,7 @@
 open class ConcatenatingLogFormatter: LogFormatter
 {
     /** The `LogFormatter`s whose output will be concatenated. */
-    open let formatters: [LogFormatter]
+    public let formatters: [LogFormatter]
 
     /** Determines the behavior of `format(_:)` when one of the receiver's
      `formatters` returns `nil`. When `false`, if any formatter returns
@@ -22,7 +22,7 @@ open class ConcatenatingLogFormatter: LogFormatter
      receiver will always return a non-`nil` value. However, when `hardFail`
      is `true`, _all_ of the `formatters` must return strings; if _any_
      formatter returns `nil`, the receiver _also_ returns `nil`. */
-    open let hardFail: Bool
+    public let hardFail: Bool
 
     /**
      Initializes a new `ConcatenatingLogFormatter` instance.

--- a/Sources/DelimiterLogFormatter.swift
+++ b/Sources/DelimiterLogFormatter.swift
@@ -32,7 +32,7 @@ public extension DelimiterStyle
     /**
      Returns the field delimiter string indicated by the receiver's value.
      */
-    public var delimiter: String {
+    var delimiter: String {
         switch self {
         case .spacedPipe:       return " | "
         case .spacedHyphen:     return " - "

--- a/Sources/FileLogRecorder.swift
+++ b/Sources/FileLogRecorder.swift
@@ -21,7 +21,7 @@ import Dispatch
 open class FileLogRecorder: LogRecorderBase
 {
     /** The path of the file to which log entries will be written. */
-    open let filePath: String
+    public let filePath: String
 
     private let file: UnsafeMutablePointer<FILE>?
     private let newlines: [Character] = ["\n", "\r"]

--- a/Sources/LogRecorderBase.swift
+++ b/Sources/LogRecorderBase.swift
@@ -15,11 +15,11 @@ open class LogRecorderBase: LogRecorder
 {
     /** The `LogFormatter`s that will be used to format messages for the
      `LogEntry`s to be logged. */
-    open let formatters: [LogFormatter]
+    public let formatters: [LogFormatter]
 
     /** The GCD queue that should be used for logging actions related to the
      receiver. */
-    open let queue: DispatchQueue
+    public let queue: DispatchQueue
 
     /**
      Initialize a new `LogRecorderBase` instance.

--- a/Sources/RotatingLogFileRecorder.swift
+++ b/Sources/RotatingLogFileRecorder.swift
@@ -20,11 +20,11 @@ open class RotatingLogFileRecorder: LogRecorderBase
 {
     /** The number of days for which the receiver will retain log files
      before they're eligible for pruning. */
-    open let daysToKeep: Int
+    public let daysToKeep: Int
 
     /** The filesystem path to a directory where the log files will be
      stored. */
-    open let directoryPath: String
+    public let directoryPath: String
 
     private static let filenameFormatter: DateFormatter = {
         let fmt = DateFormatter()

--- a/Sources/XcodeLogFormatter.swift
+++ b/Sources/XcodeLogFormatter.swift
@@ -46,7 +46,7 @@ public final class XcodeLogFormatter: LogFormatter
      - returns:  A `String` representation of `entry`, or `nil` if the
      receiver could not format the `LogEntry`.
      */
-    open func format(_ entry: LogEntry) -> String?
+    public func format(_ entry: LogEntry) -> String?
     {
         return traceFormatter.format(entry) ?? defaultFormatter.format(entry)
     }

--- a/Sources/XcodeTraceLogFormatter.swift
+++ b/Sources/XcodeTraceLogFormatter.swift
@@ -32,7 +32,7 @@ public final class XcodeTraceLogFormatter: FieldBasedLogFormatter
      - returns:  A `String` representation of `entry`, or `nil` if the
      receiver could not format the `LogEntry`.
      */
-    open override func format(_ entry: LogEntry)
+    public override func format(_ entry: LogEntry)
         -> String?
     {
         guard case .trace = entry.payload else {


### PR DESCRIPTION
Updated the package description to be compatible with the new swift package tools version, and fixed build warnings/errors related to specifying `open` vs `public` in an `open`/`final` class