### PR TITLE
Enable arm64-simulator slice creation in XCFramework by Carthage

### DIFF
--- a/BuildControl/config/Project.xcconfig
+++ b/BuildControl/config/Project.xcconfig
@@ -7,9 +7,6 @@ TARGETED_DEVICE_FAMILY = 1,2,3,4
 //
 IPHONEOS_DEPLOYMENT_TARGET = 8.0
 
-VALID_ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*] = i386 x86_64
-
 LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*] =  @executable_path/Frameworks @loader_path/Frameworks
 LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*] =  @executable_path/Frameworks @loader_path/Frameworks
 


### PR DESCRIPTION
Carthage didn't create an ARM64 slice for simulators because the xcconfig file did specify which VALID_ARCHS should be build. Removing that specification did enable Carthage to build a slice for ARM64-simulator.
That was a huge problem because on M1/Apple Silicon machines generation of code coverage reports for tests is only possible when running an ARM64 app in the simulator. Without this change one could explore ARM for simulators and only run on x64 but loose code coverage with that trick.
VALID_ARCHS is outdated and no longer available/visible in current Xcode versions anyway.